### PR TITLE
Fixed broken ddl to .deb file 

### DIFF
--- a/spot.sh
+++ b/spot.sh
@@ -4,7 +4,9 @@ echo -e "starting the process"
 blue=$(tput setaf 6)
 cd ~
 
-wget http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.2.20.1210.g2a8a8a57_amd64.deb
+#wget http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.2.20.1210.g2a8a8a57_amd64.deb
+wget https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.2.26.1187.g36b715a1_amd64.deb
+
 
 debfile=`find /home -iname "*spotify-client_1*amd64.deb"`
 echo ${blue}"found spotify deb file on" $debfile ${txtrst}


### PR DESCRIPTION
The link to download the sportify deb file was broken and returning 404, 
I replaced that link with  **latest version which is compatible with ad-block**

previous link : http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.2.20.1210.g2a8a8a57_amd64.deb

![image](https://github.com/theglitchh/spotify-adblock-linux/assets/82261530/51d1f409-b9dc-46f1-b777-7349a5620c3d)

Updated link : https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.2.26.1187.g36b715a1_amd64.deb

![image](https://github.com/theglitchh/spotify-adblock-linux/assets/82261530/54d90377-71c8-45f7-846a-7b539c9d2f1a)

**I tested it on 2 of my virtual instances kali liunix and kde neon** along with my daily driver main machine running on popOS
